### PR TITLE
NIP101 censorship resistant marketplace

### DIFF
--- a/nips/101.md
+++ b/nips/101.md
@@ -1,0 +1,155 @@
+NIP-101
+======
+
+Censorship Resistant Marketplace Suite
+--------------------------------------
+
+`draft` `optional`
+
+A suite of 6 `kinds` to build a censorship resistant marketplace.
+
+* `kind` `101` `product`
+* `kind` `102` `encrypted_order`
+* `kind` `103` `encrypted_payment`
+* `kind` `104` `encrypted_reciept`
+* `kind` `105` `encrypted_shipping`
+* `kind` `106` `feedback`
+
+End-to-end encryption between buyer and merchant is achieved using NIP04 encryption scheme
+
+## `kind` `101` `product` (merchant -> relay -> buyer)
+
+- `101`: `product`: the `content` is set to a stringified JSON object `{label: <string>, about: <string>, quantity: <available, integer>, currency: <3 char currency ie USD, string>, price: <integer>, picture: <url, string>, ships_to: <JSON object, {<country, string>: <price, integer>, <country, string>: <price, integer>, <country, string>: <price, integer>}>}` describing the product for sale.
+
+The initial `product` event `id` is the product ID for the lifetime of the product. 
+
+If `e` `tag` of an initial `product` event `id` exists in an event, the relay should treat it as a product update. The relay should keep the intial product event, and the most recent update.
+
+If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`, the lifetime of the product is over, and listings should be removed from relay.
+
+
+    ```
+    {
+      id: <32-bytes sha256 of the serialized event data>
+      pubkey: <32-bytes hex-encoded public key of the event creator>,
+      created_at: <unix timestamp>,
+      kind: 101,
+      tags: [
+        ["e",  <32-bytes hex of the inital product id>, <recommended relay URL>],
+        ... // if e tag is present event is a product update
+        ["p", <32-bytes hex of the merchants public-key>, <recommended relay URL>],
+        ... // if p tag of the merchants public-key is present, product should be removed
+      ]
+      content: <stringified JSON object>,
+      sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
+    }
+    ```
+
+
+## `kind` `102` `encrypted_order` (buyer -> relay -> merchant)
+
+- `102`: `encrypted_order`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{quantity: <integer>, name: <string>, address: <string>, phone: <string>, email: <string>}` passing order details to merchant.
+
+`e` `tag` should be set to the related `kind` `101` `product` `id`
+`s` `tag` is a 32-byte sha256 hash of the shared cipher, so the merchant can validate the cipher they generate.
+
+    ```
+    {
+      id: <32-bytes sha256 of the serialized event data>
+      pubkey: <32-bytes hex-encoded public key of the event creator>,
+      created_at: <unix timestamp>,
+      kind: 102,
+      tags: [
+        ["e",  <32-bytes hex of the product id>, <recommended relay URL>],
+        ["s", <32-byte sha256 hash of the shared cipher>],
+      ]
+      content: <base-64 encoded, aes-256-cbc encrypted, stringified JSON object>,
+      sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
+    }
+    ```
+
+## `kind` `103` `encrypted_payment` (merchant -> relay -> buyer)
+
+- `103`: `encrypted_payment`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{data: <string>, url: <string>}` passing payment details to the buyer.
+
+`e` `tag` should be set to related `kind` `102` `encrypted_order` `id`
+`s` `tag` is a 32-byte sha256 hash of the shared cipher, so the buyer can validate the cipher they generate.
+
+    ```
+    {
+      id: <32-bytes sha256 of the serialized event data>
+      pubkey: <32-bytes hex-encoded public key of the event creator>,
+      created_at: <unix timestamp>,
+      kind: 103,
+      tags: [
+        ["e",  <32-bytes hex of the encrypted_order id>, <recommended relay URL>],
+        ["s", <32-byte sha256 hash of the shared cipher>],
+      ]
+      content: <base-64 encoded, aes-256-cbc encrypted, stringified JSON object>,
+      sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
+    }
+    ```
+
+## `kind` `104` `encrypted_receipt` (buyer -> relay -> merchant)
+
+- `104`: `encrypted_receipt`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{note: <string>}` passing receipt details to the buyer.
+
+`e` `tag` should be set to related `kind` `102` `encrypted_payment` `id`
+`s` `tag` is a 32-byte sha256 hash of the shared cipher, so the merchant can validate the cipher they generate.
+
+    ```
+    {
+      id: <32-bytes sha256 of the serialized event data>
+      pubkey: <32-bytes hex-encoded public key of the event creator>,
+      created_at: <unix timestamp>,
+      kind: 104,
+      tags: [
+        ["e",  <32-bytes hex of the encrypted_payment id>, <recommended relay URL>],
+        ["s", <32-byte sha256 hash of the shared cipher>],
+      ]
+      content: <base-64 encoded, aes-256-cbc encrypted, stringified JSON object>,
+      sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
+    }
+    ```
+
+## `kind` `105` `encrypted_shipping` (merchant -> relay -> buyer)
+
+- `103`: `encrypted_shipping`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{shipped: <bool>, tracking: <URL, string>, note: <string>}` passing shipping data to buyer.
+
+`e` `tag` should be set to related `kind` `102` `encrypted_reciept` `id`
+`s` `tag` is a 32-byte sha256 hash of the shared cipher, so the buyer can validate the cipher they generate.
+
+    ```
+    {
+      id: <32-bytes sha256 of the serialized event data>
+      pubkey: <32-bytes hex-encoded public key of the event creator>,
+      created_at: <unix timestamp>,
+      kind: 105,
+      tags: [
+        ["e",  <32-bytes hex of the encrypted_reciept id>, <recommended relay URL>],
+        ["s", <32-byte sha256 hash of the shared cipher>],
+      ]
+      content: <base-64 encoded, aes-256-cbc encrypted, stringified JSON object>,
+      sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
+    }
+
+## `kind` `106` `feedback` (buyer -> relay -> merchant) / (merchant -> relay -> buyer)
+
+- `103`: `shipping`: the `content` is set to a stringified JSON object `{received: <bool>, rating: <1-100, integer>, note: <string>}` leaving feedback for the merchant/buyer.
+
+`e` `tag` should be set to `encrypted_order` `id`
+
+    ```
+    {
+      id: <32-bytes sha256 of the serialized event data>
+      pubkey: <32-bytes hex-encoded public key of the event creator>,
+      created_at: <unix timestamp>,
+      kind: 106,
+      tags: [
+        ["e",  <32-bytes hex of the encrypted_order id>, <recommended relay URL>],
+        ["p", <32-bytes hex of the merchants/buyers public-key>, <recommended relay URL>],
+      ]
+      content: <stringified JSON object>,
+      sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
+    }
+    ```

--- a/nips/101.md
+++ b/nips/101.md
@@ -53,6 +53,7 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 `102`: `encrypted_order`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{quantity: <integer>, name: <string>, address: <string>, phone: <string>, email: <string>}` passing order details to merchant.
 
 `e` `tag` should be set to the related `kind` `101` `product` `id`
+
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the merchant can validate the cipher they generate.
 
     {
@@ -73,6 +74,7 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 `103`: `encrypted_payment`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{data: <string>, url: <string>}` passing payment details to the buyer.
 
 `e` `tag` should be set to related `kind` `102` `encrypted_order` `id`
+
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the buyer can validate the cipher they generate.
 
     {
@@ -93,6 +95,7 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 `104`: `encrypted_receipt`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{note: <string>}` passing receipt details to the buyer.
 
 `e` `tag` should be set to related `kind` `102` `encrypted_payment` `id`
+
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the merchant can validate the cipher they generate.
 
     {
@@ -113,6 +116,7 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 `105`: `encrypted_shipping`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{shipped: <bool>, tracking: <URL, string>, note: <string>}` passing shipping data to buyer.
 
 `e` `tag` should be set to related `kind` `102` `encrypted_reciept` `id`
+
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the buyer can validate the cipher they generate.
 
     {

--- a/nips/101.md
+++ b/nips/101.md
@@ -17,6 +17,8 @@ A suite of 6 `kinds` to build a censorship resistant marketplace on Nostr networ
 
 End-to-end encryption between buyer and merchant is achieved using NIP04 encryption scheme https://github.com/fiatjaf/nostr/pull/10
 
+Direct encrypted messaging between buyer and merchant are possible using NIP04 with `e` `tag` set to the `encrypted_order` `id` 
+
 In this use of Nostr, clients become market stalls of products and relays become online locations customers can browse and buy products from.
 
 ## `kind` `101` `product` (merchant -> relay -> buyer)

--- a/nips/101.md
+++ b/nips/101.md
@@ -19,7 +19,7 @@ End-to-end encryption between buyer and merchant is achieved using NIP04 encrypt
 
 Direct encrypted messaging between buyer and merchant are possible using NIP04 with `e` `tag` set to the `encrypted_order` `id` 
 
-In this use of Nostr, clients become market stalls of products and relays become online locations customers can browse and buy products from.
+The best way to use NIP101 is if the buyer and merchant are both clients, an ecommerce management client for the merchant, and a shop client for the buyer (Nostr clients could be run as a service, or by the users themselves).   
 
 ## `kind` `101` `product` (merchant -> relay -> buyer)
 

--- a/nips/101.md
+++ b/nips/101.md
@@ -28,7 +28,6 @@ If `e` `tag` of an initial `product` event `id` exists in an event, the relay sh
 If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`, the lifetime of the product is over, and listings should be removed from relay.
 
 
-    ```
     {
       id: <32-bytes sha256 of the serialized event data>
       pubkey: <32-bytes hex-encoded public key of the event creator>,
@@ -43,7 +42,6 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
       content: <stringified JSON object>,
       sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
     }
-    ```
 
 
 ## `kind` `102` `encrypted_order` (buyer -> relay -> merchant)
@@ -53,7 +51,6 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 `e` `tag` should be set to the related `kind` `101` `product` `id`
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the merchant can validate the cipher they generate.
 
-    ```
     {
       id: <32-bytes sha256 of the serialized event data>
       pubkey: <32-bytes hex-encoded public key of the event creator>,
@@ -66,7 +63,6 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
       content: <base-64 encoded, aes-256-cbc encrypted, stringified JSON object>,
       sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
     }
-    ```
 
 ## `kind` `103` `encrypted_payment` (merchant -> relay -> buyer)
 
@@ -75,7 +71,6 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 `e` `tag` should be set to related `kind` `102` `encrypted_order` `id`
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the buyer can validate the cipher they generate.
 
-    ```
     {
       id: <32-bytes sha256 of the serialized event data>
       pubkey: <32-bytes hex-encoded public key of the event creator>,
@@ -88,7 +83,6 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
       content: <base-64 encoded, aes-256-cbc encrypted, stringified JSON object>,
       sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
     }
-    ```
 
 ## `kind` `104` `encrypted_receipt` (buyer -> relay -> merchant)
 
@@ -97,7 +91,6 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 `e` `tag` should be set to related `kind` `102` `encrypted_payment` `id`
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the merchant can validate the cipher they generate.
 
-    ```
     {
       id: <32-bytes sha256 of the serialized event data>
       pubkey: <32-bytes hex-encoded public key of the event creator>,
@@ -110,7 +103,6 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
       content: <base-64 encoded, aes-256-cbc encrypted, stringified JSON object>,
       sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
     }
-    ```
 
 ## `kind` `105` `encrypted_shipping` (merchant -> relay -> buyer)
 
@@ -119,7 +111,6 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 `e` `tag` should be set to related `kind` `102` `encrypted_reciept` `id`
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the buyer can validate the cipher they generate.
 
-    ```
     {
       id: <32-bytes sha256 of the serialized event data>
       pubkey: <32-bytes hex-encoded public key of the event creator>,
@@ -139,7 +130,6 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 
 `e` `tag` should be set to `encrypted_order` `id`
 
-    ```
     {
       id: <32-bytes sha256 of the serialized event data>
       pubkey: <32-bytes hex-encoded public key of the event creator>,
@@ -152,4 +142,3 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
       content: <stringified JSON object>,
       sig: <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>,
     }
-    ```

--- a/nips/101.md
+++ b/nips/101.md
@@ -11,7 +11,7 @@ A suite of 6 `kinds` to build a censorship resistant marketplace on Nostr networ
 * `kind` `101` `product`
 * `kind` `102` `encrypted_order`
 * `kind` `103` `encrypted_payment`
-* `kind` `104` `encrypted_reciept`
+* `kind` `104` `encrypted_receipt`
 * `kind` `105` `encrypted_shipping`
 * `kind` `106` `feedback`
 

--- a/nips/101.md
+++ b/nips/101.md
@@ -6,7 +6,7 @@ Censorship Resistant Marketplace Suite
 
 `draft` `optional`
 
-A suite of 6 `kinds` to build a censorship resistant marketplace.
+A suite of 6 `kinds` to build a censorship resistant marketplace on Nostr network
 
 * `kind` `101` `product`
 * `kind` `102` `encrypted_order`
@@ -16,6 +16,8 @@ A suite of 6 `kinds` to build a censorship resistant marketplace.
 * `kind` `106` `feedback`
 
 End-to-end encryption between buyer and merchant is achieved using NIP04 encryption scheme https://github.com/fiatjaf/nostr/pull/10
+
+In this use of Nostr, clients become market stalls of products and relays become online locations customers can browse and buy products from.
 
 ## `kind` `101` `product` (merchant -> relay -> buyer)
 

--- a/nips/101.md
+++ b/nips/101.md
@@ -15,7 +15,7 @@ A suite of 6 `kinds` to build a censorship resistant marketplace.
 * `kind` `105` `encrypted_shipping`
 * `kind` `106` `feedback`
 
-End-to-end encryption between buyer and merchant is achieved using NIP04 encryption scheme
+End-to-end encryption between buyer and merchant is achieved using NIP04 encryption scheme https://github.com/fiatjaf/nostr/pull/10
 
 ## `kind` `101` `product` (merchant -> relay -> buyer)
 

--- a/nips/101.md
+++ b/nips/101.md
@@ -23,7 +23,7 @@ The best way to use NIP101 is if the buyer and merchant are both clients, an eco
 
 ## `kind` `101` `product` (merchant -> relay -> buyer)
 
-`101`: `product`: the `content` is set to a stringified JSON object `{label: <string>, about: <string>, quantity: <available, integer>, currency: <3 char currency ie USD, string>, price: <integer>, picture: <url, string>, ships_to: <JSON object, {<country, string>: <price, integer>, <country, string>: <price, integer>, <country, string>: <price, integer>}>}` describing the product for sale.
+`101`: `product`: the `content` is set to a stringified JSON object `{label: <string>, about: <string>, category: <JSON array object>, quantity: <available, integer>, currency: <3 char currency ie USD, string>, price: <integer>, picture: <url, string>, ships_to: <JSON object, {<country, string>: <price, integer>, <country, string>: <price, integer>, <country, string>: <price, integer>}>}` describing the product for sale.
 
 The initial `product` event `id` is the product ID for the lifetime of the product. 
 

--- a/nips/101.md
+++ b/nips/101.md
@@ -19,7 +19,7 @@ End-to-end encryption between buyer and merchant is achieved using NIP04 encrypt
 
 ## `kind` `101` `product` (merchant -> relay -> buyer)
 
-- `101`: `product`: the `content` is set to a stringified JSON object `{label: <string>, about: <string>, quantity: <available, integer>, currency: <3 char currency ie USD, string>, price: <integer>, picture: <url, string>, ships_to: <JSON object, {<country, string>: <price, integer>, <country, string>: <price, integer>, <country, string>: <price, integer>}>}` describing the product for sale.
+`101`: `product`: the `content` is set to a stringified JSON object `{label: <string>, about: <string>, quantity: <available, integer>, currency: <3 char currency ie USD, string>, price: <integer>, picture: <url, string>, ships_to: <JSON object, {<country, string>: <price, integer>, <country, string>: <price, integer>, <country, string>: <price, integer>}>}` describing the product for sale.
 
 The initial `product` event `id` is the product ID for the lifetime of the product. 
 
@@ -48,7 +48,7 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 
 ## `kind` `102` `encrypted_order` (buyer -> relay -> merchant)
 
-- `102`: `encrypted_order`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{quantity: <integer>, name: <string>, address: <string>, phone: <string>, email: <string>}` passing order details to merchant.
+`102`: `encrypted_order`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{quantity: <integer>, name: <string>, address: <string>, phone: <string>, email: <string>}` passing order details to merchant.
 
 `e` `tag` should be set to the related `kind` `101` `product` `id`
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the merchant can validate the cipher they generate.
@@ -70,7 +70,7 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 
 ## `kind` `103` `encrypted_payment` (merchant -> relay -> buyer)
 
-- `103`: `encrypted_payment`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{data: <string>, url: <string>}` passing payment details to the buyer.
+`103`: `encrypted_payment`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{data: <string>, url: <string>}` passing payment details to the buyer.
 
 `e` `tag` should be set to related `kind` `102` `encrypted_order` `id`
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the buyer can validate the cipher they generate.
@@ -92,7 +92,7 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 
 ## `kind` `104` `encrypted_receipt` (buyer -> relay -> merchant)
 
-- `104`: `encrypted_receipt`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{note: <string>}` passing receipt details to the buyer.
+`104`: `encrypted_receipt`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{note: <string>}` passing receipt details to the buyer.
 
 `e` `tag` should be set to related `kind` `102` `encrypted_payment` `id`
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the merchant can validate the cipher they generate.
@@ -114,7 +114,7 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 
 ## `kind` `105` `encrypted_shipping` (merchant -> relay -> buyer)
 
-- `103`: `encrypted_shipping`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{shipped: <bool>, tracking: <URL, string>, note: <string>}` passing shipping data to buyer.
+`105`: `encrypted_shipping`: the `content` is set to a base-64 encoded, aes-256-cbc encrypted, stringified JSON object `{shipped: <bool>, tracking: <URL, string>, note: <string>}` passing shipping data to buyer.
 
 `e` `tag` should be set to related `kind` `102` `encrypted_reciept` `id`
 `s` `tag` is a 32-byte sha256 hash of the shared cipher, so the buyer can validate the cipher they generate.
@@ -135,7 +135,7 @@ If an update includes `p` `tag` with `32-byte` `hex` of signers own `public-key`
 
 ## `kind` `106` `feedback` (buyer -> relay -> merchant) / (merchant -> relay -> buyer)
 
-- `103`: `shipping`: the `content` is set to a stringified JSON object `{received: <bool>, rating: <1-100, integer>, note: <string>}` leaving feedback for the merchant/buyer.
+`106`: `shipping`: the `content` is set to a stringified JSON object `{received: <bool>, rating: <1-100, integer>, note: <string>}` leaving feedback for the merchant/buyer.
 
 `e` `tag` should be set to `encrypted_order` `id`
 


### PR DESCRIPTION
Some Nostr note kinds for a censorship resistant marketplace. 

This is based on Diagon Alley, the protocol that partly influenced Nostr, where clients are market stalls of products, and relays are online product indexers. 
https://github.com/lnbits/Diagon-Alley

The best way to use NIP101 is if the buyer and merchant are both clients, an ecommerce management client for the merchant, and a shop client for the buyer (Nostr clients could be run as a service, or by the users themselves).   


The ordering process is end-to-end encrypted between buyer and merchant.