### PR TITLE
removed "Relays don't have to be trusted"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a work in progress. [Join the Telegram group!](https://t.me/nostr_protoc
 
 ## Very short summary of how it works, if you don't plan to read anything else:
 
-Everybody runs a client. It can be a native client, a web client, etc. To publish something, you write a post, sign it with your key and send it to multiple relays (servers hosted by someone else, or yourself). To get updates from other people, you ask multiple relays if they know anything about these other people. Anyone can run a relay. A relay is very simple and dumb. It does nothing besides accepting posts from some people and forwarding to others. Relays don't have to be trusted. Signatures are verified on the client side.
+Everybody runs a client. It can be a native client, a web client, etc. To publish something, you write a post, sign it with your key and send it to multiple relays (servers hosted by someone else, or yourself). To get updates from other people, you ask multiple relays if they know anything about these other people. Anyone can run a relay. A relay is very simple and dumb. It does nothing besides accepting posts from some people and forwarding to others. Signatures are verified on the client side.
 
 [How to start using Nostr](https://github.com/vishalxl/nostr_console/discussions/31)
 


### PR DESCRIPTION
removed "Relays don't have to be trusted" under "## Very short summary of how it works, if you don't plan to read anything else": Obviously relays has to be trusted by user who choose to store their data there.