### PR TITLE
Remove NIP files in /nips 

### DIFF
--- a/nips/01.md
+++ b/nips/01.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/01.md

--- a/nips/02.md
+++ b/nips/02.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/02.md

--- a/nips/03.md
+++ b/nips/03.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/03.md

--- a/nips/04.md
+++ b/nips/04.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/04.md

--- a/nips/05.md
+++ b/nips/05.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/05.md

--- a/nips/06.md
+++ b/nips/06.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/06.md

--- a/nips/08.md
+++ b/nips/08.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/08.md

--- a/nips/09.md
+++ b/nips/09.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/09.md

--- a/nips/11.md
+++ b/nips/11.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/11.md

--- a/nips/12.md
+++ b/nips/12.md
@@ -1,1 +1,0 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/12.md

--- a/nips/README.md
+++ b/nips/README.md
@@ -2,7 +2,7 @@
 
 # NIPs
 
-NIPs stand for **Nostr Implementation Possibilities**.
+NIPs stand for **Nostr Implementation Possibilities**.  
 They exist to document what may be implemented by Nostr-compatible relay and client software.
 
 List of NIPs: https://github.com/nostr-protocol/nips?tab=readme-ov-file#list 

--- a/nips/README.md
+++ b/nips/README.md
@@ -1,6 +1,6 @@
-> 💡 The original page was moved to https://github.com/nostr-protocol/nips/blob/master/README.md
+# 💡 The original page was moved to https://github.com/nostr-protocol/nips/blob/master/README.md
 
-# NIPs
+## NIPs
 
 NIPs stand for **Nostr Implementation Possibilities**.  
 They exist to document what may be implemented by Nostr-compatible relay and client software.

--- a/nips/README.md
+++ b/nips/README.md
@@ -1,1 +1,8 @@
-This page was moved to https://github.com/nostr-protocol/nips/blob/master/README.md
+> 💡 The original page was moved to https://github.com/nostr-protocol/nips/blob/master/README.md
+
+# NIPs
+
+NIPs stand for **Nostr Implementation Possibilities**.
+They exist to document what may be implemented by Nostr-compatible relay and client software.
+
+List of NIPs: https://github.com/nostr-protocol/nips?tab=readme-ov-file#list 


### PR DESCRIPTION
Currently there are 12 NIP files in the directory so it seems there are only 12 NIPs. There are many more, but in a different repo. I think it's better to:
1. Remove all the mentioned NIPs in this directory
2. Or show all current NIPs (but this has to be actively maintained which is not likely to happen)

This repo gets the most eyes of the world when they are looking for Nostr, so I think this will help to make it more clear why there are NIPs and where to find them.